### PR TITLE
update the prepare_release.md file to ensure that the release happens…

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/prepare_release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/prepare_release.md
@@ -8,9 +8,11 @@ Closes # <-- add issue number for the release issue -->
   - [ ] create new header for PyPSA-Zambia release
   - [ ] move "next release" notes under header
   - [ ] add "next release" headers
-- [ ] Create annotated tag `git tag -a vX.Y -m "Release vX.Y"` on the release branch
+- [ ] Ensure the release branch named `release_vX.Y`, is merged into main
+- [ ] Switch to main branch using `git checkout main`
+- [ ] Create annotated tag `git tag -a vX.Y -m "Release vX.Y"` on the main branch
 - [ ] Push the tag to the server e.g. `git push origin vX.Y`
-- [ ] Create  the draft release on Github selecting the tag you just pushed
+- [ ] Create  the draft release on Github selecting the tag you just pushed, ensure you are on the main branch.
 - [ ] Update the release notes on Github with a copy of the release notes from the documentation
 - [ ] Append any artefacts such as:
   - [ ] installer packages

--- a/.github/PULL_REQUEST_TEMPLATE/prepare_release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/prepare_release.md
@@ -9,10 +9,7 @@ Closes # <-- add issue number for the release issue -->
   - [ ] move "next release" notes under header
   - [ ] add "next release" headers
 - [ ] Ensure the release branch named `release_vX.Y`, is merged into main
-- [ ] Switch to main branch using `git checkout main`
-- [ ] Create annotated tag `git tag -a vX.Y -m "Release vX.Y"` on the main branch
-- [ ] Push the tag to the server e.g. `git push origin vX.Y`
-- [ ] Create  the draft release on Github selecting the tag you just pushed, ensure you are on the main branch.
+- [ ] Create  the draft release on Github and create a new tag, ensure you are on the main branch.
 - [ ] Update the release notes on Github with a copy of the release notes from the documentation
 - [ ] Append any artefacts such as:
   - [ ] installer packages

--- a/doc/configtables/snippets/costs.yaml
+++ b/doc/configtables/snippets/costs.yaml
@@ -21,7 +21,7 @@ costs:
     lifetime: 25
     CO2 intensity: 0
     discount rate: 0.07
-  marginal_cost: # EUR/MWh — IRP Table 5 (Zambia 2023), converted at 0.7532 EUR/USD
+  marginal_cost: # EUR/MWh — IRP Table 9 (Zambia 2023), converted at 0.7532 EUR/USD
     solar: 0
     onwind: 0
     offwind: 0.015


### PR DESCRIPTION
# Closes issue [# 142](https://github.com/orgs/open-energy-transition/projects/66/views/2?pane=issue&itemId=171084384&issue=open-energy-transition%7Cpypsa-zambia%7C142)

## Changes proposed in this Pull Request
The current release process describes a way that results into the release being made on a squashed commit. The reason for this is that the release tag and the release are being done on the branch instead of main. Creating the release on main right after merging the PR with the updated release notes ensures that the release captures the current state of main as well as being tagged onto the main branch which is the ideal case.

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented, including updates to docstrings for meaningful functions.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/user-guide/configuration.md` and `doc/tutorials/electricity-model.md`.
- [ ] If config sections were added, renamed, or removed, update `doc/assets/scripts/extract_config_snippets.py` accordingly.
- [ ] Archives of the uploaded data do not have an enclosing folder and archive names correspond to the conventions of `configs/bundle_config.yaml`.
- [ ] A note for the release notes `doc/release-notes.md` is amended in the format of previous release notes, including reference to the requested PR.
