### PR TITLE
add lead time feature

### DIFF
--- a/configs/cap_exp_zambia.yaml
+++ b/configs/cap_exp_zambia.yaml
@@ -16,10 +16,11 @@ scenario:
   ll: ["copt"]
   clusters: ["10"]
   opts: [3h]
+  base_year: 2025
 
 electricity:
   extendable_carriers:
-    Generator: ["solar"]
+    Generator: ["solar", "biomass", "geothermal", "hydro", "ror", "coal", "nuclear", "csp-tower", "oil", "onwind"]
     StorageUnit: []
     Store: []
     Link: []
@@ -47,3 +48,37 @@ costs:
   marginal_cost:
     coal: 0.0
     oil: 4.23
+  co2_emissions: # tCO2/MWh — IRP Table 5 (Zambia 2023)
+    hydro: 0.025
+    ror: 0.024
+    coal: 0.830
+    geothermal: 0.038
+    biomass: 0.038
+    solar: 0.048
+    onwind: 0.011
+    nuclear: 0.012
+    csp-tower: 0.000
+    oil: 0.490
+  apply_lead_time: true
+  lead_time: # years — IRP Table 5 (Zambia 2023)
+    hydro: 5
+    ror: 3
+    coal: 5
+    geothermal: 4
+    biomass: 3
+    solar: 2
+    onwind: 3
+    nuclear: 10
+    csp-tower: 4
+    oil: 3
+  lifetime: # years — IRP Table 5 (Zambia 2023)
+    hydro: 50
+    ror: 35
+    coal: 40
+    geothermal: 35
+    biomass: 25
+    solar: 25
+    onwind: 30
+    nuclear: 50
+    csp-tower: 25
+    oil: 30

--- a/configs/cap_exp_zambia.yaml
+++ b/configs/cap_exp_zambia.yaml
@@ -16,7 +16,6 @@ scenario:
   ll: ["copt"]
   clusters: ["10"]
   opts: [3h]
-  base_year: 2025
 
 electricity:
   extendable_carriers:
@@ -59,18 +58,6 @@ costs:
     nuclear: 0.012
     csp-tower: 0.000
     oil: 0.490
-  apply_lead_time: true
-  lead_time: # years — IRP Table 5 (Zambia 2023)
-    hydro: 5
-    ror: 3
-    coal: 5
-    geothermal: 4
-    biomass: 3
-    solar: 2
-    onwind: 3
-    nuclear: 10
-    csp-tower: 4
-    oil: 3
   lifetime: # years — IRP Table 5 (Zambia 2023)
     hydro: 50
     ror: 35

--- a/configs/cap_exp_zambia.yaml
+++ b/configs/cap_exp_zambia.yaml
@@ -19,6 +19,8 @@ scenario:
 
 electricity:
   extendable_carriers:
+    # TODO Biomass potential can have strong impact and must be adjusted
+    # according to the conditions it aims to represent
     Generator: ["solar", "biomass", "hydro", "ror", "oil", "onwind"]
     StorageUnit: []
     Store: []

--- a/configs/cap_exp_zambia.yaml
+++ b/configs/cap_exp_zambia.yaml
@@ -19,7 +19,7 @@ scenario:
 
 electricity:
   extendable_carriers:
-    Generator: ["solar", "biomass", "geothermal", "hydro", "ror", "coal", "nuclear", "csp-tower", "oil", "onwind"]
+    Generator: ["solar", "biomass", "hydro", "ror", "oil", "onwind"]
     StorageUnit: []
     Store: []
     Link: []

--- a/configs/validation_dispatch_zambia.yaml
+++ b/configs/validation_dispatch_zambia.yaml
@@ -131,6 +131,40 @@ costs:
     biomass: 4.14
     nuclear: 3.46
     csp: 0.
+  co2_emissions: # tCO2/MWh — IRP Table 5 (Zambia 2023)
+    hydro: 0.025
+    ror: 0.024
+    coal: 0.830
+    geothermal: 0.038
+    biomass: 0.038
+    solar: 0.048
+    onwind: 0.011
+    nuclear: 0.012
+    csp-tower: 0.000
+    oil: 0.490
+  apply_lead_time: false
+  lead_time: # years — IRP Table 5 (Zambia 2023)
+    hydro: 5
+    ror: 3
+    coal: 5
+    geothermal: 4
+    biomass: 3
+    solar: 2
+    onwind: 3
+    nuclear: 10
+    csp-tower: 4
+    oil: 3
+  lifetime: # years — IRP Table 5 (Zambia 2023)
+    hydro: 50
+    ror: 35
+    coal: 40
+    geothermal: 35
+    biomass: 25
+    solar: 25
+    onwind: 30
+    nuclear: 50
+    csp-tower: 25
+    oil: 30
 
 cluster_options:
   simplify_network:

--- a/configs/validation_dispatch_zambia.yaml
+++ b/configs/validation_dispatch_zambia.yaml
@@ -142,18 +142,6 @@ costs:
     nuclear: 0.012
     csp-tower: 0.000
     oil: 0.490
-  apply_lead_time: false
-  lead_time: # years — IRP Table 5 (Zambia 2023)
-    hydro: 5
-    ror: 3
-    coal: 5
-    geothermal: 4
-    biomass: 3
-    solar: 2
-    onwind: 3
-    nuclear: 10
-    csp-tower: 4
-    oil: 3
   lifetime: # years — IRP Table 5 (Zambia 2023)
     hydro: 50
     ror: 35

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -18,6 +18,8 @@ This part of documentation collects descriptive release notes to capture the mai
 
 * Added link to data versioning in docs, and tidied up the links and licenses in the data inventory [PR #233](https://github.com/open-energy-transition/pypsa-zambia/pull/233)
 
+* Added a baseline configuration for capacity expansion runs [PR #242](https://github.com/open-energy-transition/pypsa-zambia/pull/242)
+
 
 # PyPSA-Zambia v0.3
 

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -94,7 +94,11 @@ from _helpers import (
     update_p_nom_max,
 )
 from powerplantmatching.export import map_country_bus
-from utility_custom_features import add_biomass_potential, disaggregate_plants
+from utility_custom_features import (
+    add_biomass_potential,
+    disaggregate_plants,
+    filter_carriers_by_lead_time,
+)
 
 idx = pd.IndexSlice
 
@@ -1362,6 +1366,20 @@ if __name__ == "__main__":
         renewable_carriers = set(snakemake.params.renewable)
 
     extendable_carriers = snakemake.params.electricity["extendable_carriers"]
+
+    lead_time_active = snakemake.config["costs"].get("apply_lead_time", False)
+    lead_times = snakemake.config["costs"].get("lead_time", {})
+    if lead_time_active and lead_times:
+        base_year = snakemake.config["scenario"].get("base_year")
+        if base_year is None:
+            raise ValueError(
+                "costs.apply_lead_time is True but scenario.base_year is not set in config."
+            )
+        planning_year = snakemake.config["costs"]["year"]
+        extendable_carriers["Generator"] = filter_carriers_by_lead_time(
+            extendable_carriers["Generator"], lead_times, base_year, planning_year
+        )
+
     if not (set(renewable_carriers) & set(extendable_carriers["Generator"])):
         logger.warning(
             "No renewables found in config entry `extendable_carriers`. "
@@ -1407,7 +1425,14 @@ if __name__ == "__main__":
     if snakemake.params.electricity.get("biomass_potential"):
         _add_missing_carriers_from_costs(n, costs, ["biomass"])
         biomass_gdf = gpd.read_file(snakemake.input.biomass_geojson)
-        add_biomass_potential(n, biomass_gdf, costs, geo_crs)
+        if lead_time_active and lead_times:
+            window = snakemake.config["costs"]["year"] - base_year
+            biomass_extendable = lead_times.get("biomass", 0) <= window
+        else:
+            biomass_extendable = True
+        add_biomass_potential(
+            n, biomass_gdf, costs, geo_crs, extendable=biomass_extendable
+        )
 
     apply_nuclear_p_max_pu(
         n,

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -97,7 +97,6 @@ from powerplantmatching.export import map_country_bus
 from utility_custom_features import (
     add_biomass_potential,
     disaggregate_plants,
-    filter_carriers_by_lead_time,
 )
 
 idx = pd.IndexSlice
@@ -1367,19 +1366,6 @@ if __name__ == "__main__":
 
     extendable_carriers = snakemake.params.electricity["extendable_carriers"]
 
-    lead_time_active = snakemake.config["costs"].get("apply_lead_time", False)
-    lead_times = snakemake.config["costs"].get("lead_time", {})
-    if lead_time_active and lead_times:
-        base_year = snakemake.config["scenario"].get("base_year")
-        if base_year is None:
-            raise ValueError(
-                "costs.apply_lead_time is True but scenario.base_year is not set in config."
-            )
-        planning_year = snakemake.config["costs"]["year"]
-        extendable_carriers["Generator"] = filter_carriers_by_lead_time(
-            extendable_carriers["Generator"], lead_times, base_year, planning_year
-        )
-
     if not (set(renewable_carriers) & set(extendable_carriers["Generator"])):
         logger.warning(
             "No renewables found in config entry `extendable_carriers`. "
@@ -1425,14 +1411,7 @@ if __name__ == "__main__":
     if snakemake.params.electricity.get("biomass_potential"):
         _add_missing_carriers_from_costs(n, costs, ["biomass"])
         biomass_gdf = gpd.read_file(snakemake.input.biomass_geojson)
-        if lead_time_active and lead_times:
-            window = snakemake.config["costs"]["year"] - base_year
-            biomass_extendable = lead_times.get("biomass", 0) <= window
-        else:
-            biomass_extendable = True
-        add_biomass_potential(
-            n, biomass_gdf, costs, geo_crs, extendable=biomass_extendable
-        )
+        add_biomass_potential(n, biomass_gdf, costs, geo_crs)
 
     apply_nuclear_p_max_pu(
         n,

--- a/scripts/process_cost_data.py
+++ b/scripts/process_cost_data.py
@@ -354,8 +354,18 @@ def load_costs(
         ]
 
     costs = costs.value.unstack().fillna(config["fill_values"])
+    costs = costs.rename(columns={"CO2 intensity": "co2_emissions"})
 
-    for attr in ("investment", "lifetime", "FOM", "VOM", "efficiency", "fuel"):
+    for attr in (
+        "investment",
+        "lifetime",
+        "lead_time",
+        "FOM",
+        "VOM",
+        "efficiency",
+        "fuel",
+        "co2_emissions",
+    ):
         overwrites = config.get(attr)
         if overwrites is not None:
             overwrites = pd.Series(overwrites)
@@ -374,8 +384,6 @@ def load_costs(
     costs.at["CCGT", "fuel"] = costs.at["gas", "fuel"]
 
     costs["marginal_cost"] = costs["VOM"] + costs["fuel"] / costs["efficiency"]
-
-    costs = costs.rename(columns={"CO2 intensity": "co2_emissions"})
     # rename because technology data & pypsa earth costs.csv use different names
     # TODO: rename the technologies in hosted tutorial data to match technology data
     costs = costs.rename(

--- a/scripts/process_cost_data.py
+++ b/scripts/process_cost_data.py
@@ -359,7 +359,6 @@ def load_costs(
     for attr in (
         "investment",
         "lifetime",
-        "lead_time",
         "FOM",
         "VOM",
         "efficiency",

--- a/scripts/utility_custom_features.py
+++ b/scripts/utility_custom_features.py
@@ -22,8 +22,8 @@ from shapely.ops import transform as shapely_transform
 logger = logging.getLogger(__name__)
 
 
-def add_biomass_potential(n, biomass_gdf, costs, geo_crs):
-    """Add extendable biomass generators to Zambian buses.
+def add_biomass_potential(n, biomass_gdf, costs, geo_crs, extendable=True):
+    """Add biomass generators to Zambian buses.
 
     biomass_gdf comes from biomass.geojson which has province shapes
     and biomass_mw capacity already merged into one file.
@@ -31,6 +31,8 @@ def add_biomass_potential(n, biomass_gdf, costs, geo_crs):
     If a bus already has a biomass generator (e.g. added earlier because
     biomass is in extendable_carriers), we just update its p_nom_max
     instead of adding a duplicate.
+    extendable controls whether the generators can be expanded by the solver.
+    Set to False when the lead time filter excludes biomass.
     """
     zm_buses = n.buses[n.buses.country == "ZM"]
     zm_bus_points = gpd.GeoDataFrame(
@@ -58,11 +60,28 @@ def add_biomass_potential(n, biomass_gdf, costs, geo_crs):
         bus=buses_to_add,
         carrier="biomass",
         p_nom=0.0,
-        p_nom_extendable=True,
+        p_nom_extendable=extendable,
         p_nom_max=p_nom_max[buses_to_add],
         capital_cost=costs.at["biomass", "capital_cost"],
         marginal_cost=costs.at["biomass", "marginal_cost"],
     )
+
+
+def filter_carriers_by_lead_time(carriers, lead_times, base_year, planning_year):
+    """Return only carriers that can be built within the available time window.
+
+    For example with base_year=2025 and planning_year=2030 the window is 5 years.
+    Nuclear needs 10 years so it is excluded. Solar needs 2 years so it passes.
+    """
+    window = planning_year - base_year
+    available = [c for c in carriers if lead_times.get(c, 0) <= window]
+    excluded = [c for c in carriers if c not in available]
+    if excluded:
+        logger.info(
+            f"Lead time filter ({base_year}→{planning_year}, window={window} yrs): "
+            f"excluding {excluded}."
+        )
+    return available
 
 
 def annual_gwh_to_average_mw(energy_gwh, hours_per_year=8760):

--- a/scripts/utility_custom_features.py
+++ b/scripts/utility_custom_features.py
@@ -22,8 +22,8 @@ from shapely.ops import transform as shapely_transform
 logger = logging.getLogger(__name__)
 
 
-def add_biomass_potential(n, biomass_gdf, costs, geo_crs, extendable=True):
-    """Add biomass generators to Zambian buses.
+def add_biomass_potential(n, biomass_gdf, costs, geo_crs):
+    """Add extendable biomass generators to Zambian buses.
 
     biomass_gdf comes from biomass.geojson which has province shapes
     and biomass_mw capacity already merged into one file.
@@ -31,8 +31,6 @@ def add_biomass_potential(n, biomass_gdf, costs, geo_crs, extendable=True):
     If a bus already has a biomass generator (e.g. added earlier because
     biomass is in extendable_carriers), we just update its p_nom_max
     instead of adding a duplicate.
-    extendable controls whether the generators can be expanded by the solver.
-    Set to False when the lead time filter excludes biomass.
     """
     zm_buses = n.buses[n.buses.country == "ZM"]
     zm_bus_points = gpd.GeoDataFrame(
@@ -60,28 +58,11 @@ def add_biomass_potential(n, biomass_gdf, costs, geo_crs, extendable=True):
         bus=buses_to_add,
         carrier="biomass",
         p_nom=0.0,
-        p_nom_extendable=extendable,
+        p_nom_extendable=True,
         p_nom_max=p_nom_max[buses_to_add],
         capital_cost=costs.at["biomass", "capital_cost"],
         marginal_cost=costs.at["biomass", "marginal_cost"],
     )
-
-
-def filter_carriers_by_lead_time(carriers, lead_times, base_year, planning_year):
-    """Return only carriers that can be built within the available time window.
-
-    For example with base_year=2025 and planning_year=2030 the window is 5 years.
-    Nuclear needs 10 years so it is excluded. Solar needs 2 years so it passes.
-    """
-    window = planning_year - base_year
-    available = [c for c in carriers if lead_times.get(c, 0) <= window]
-    excluded = [c for c in carriers if c not in available]
-    if excluded:
-        logger.info(
-            f"Lead time filter ({base_year}→{planning_year}, window={window} yrs): "
-            f"excluding {excluded}."
-        )
-    return available
 
 
 def annual_gwh_to_average_mw(energy_gwh, hours_per_year=8760):


### PR DESCRIPTION
## Changes proposed in this Pull Request

 This PR introduces a lead time filter for capacity expansion in PyPSA-Zambia. When       
  apply_lead_time: true is set in the config, only technologies whose construction time fits 
  within the planning window (costs.year − scenario.base_year) are made extendable,
  preventing the solver from building plants that could not realistically be commissioned in 
  time. The feature is activated via a config flag and is off by default, leaving existing
  workflows unchanged. Cost parameters (investment, lifetime, lead time, CO₂ emissions)    
  follow IRP Table 5 (Zambia 2023).

<--Add a summary of what the contribution contains -->

## Checklist

<--This checklist must be filled in. If the item is not applicable, tick anyway.-->

- [ ] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented, including updates to docstrings for meaningful functions.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/user-guide/configuration.md` and `doc/tutorials/electricity-model.md`.
- [ ] If config sections were added, renamed, or removed, update `doc/assets/scripts/extract_config_snippets.py` accordingly.
- [ ] Archives of the uploaded data do not have an enclosing folder and archive names correspond to the conventions of `configs/bundle_config.yaml`.
- [ ] A note for the release notes `doc/release-notes.md` is amended in the format of previous release notes, including reference to the requested PR.
