### PR TITLE
Feature: Add cross-scenario comparison plots (compare_scenarios)

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -2426,3 +2426,23 @@ rule run_all_scenarios:
                 for c in Path("configs/scenarios_zambia").glob("config.*.yaml")
             ],
         ),
+
+
+rule compare_scenarios:
+    """Cross-scenario comparison plots (capacity, generation, demand, spatial maps).
+
+    Run after solving networks:
+        snakemake compare_scenarios
+
+    Or standalone (auto-discovers all results/):
+        python scripts/plot_scenario_comparison.py
+    """
+    params:
+        results_dir="results/",
+        base_dir=".",
+    output:
+        directory("results/comparison_plots"),
+    log:
+        "logs/compare_scenarios.log",
+    script:
+        "scripts/plot_scenario_comparison.py"

--- a/Snakefile
+++ b/Snakefile
@@ -83,6 +83,7 @@ wildcard_constraints:
 
 
 include: "rules/retrieve.smk"
+include: "rules/postprocessing.smk"
 
 
 if config["custom_rules"] is not []:
@@ -2426,24 +2427,3 @@ rule run_all_scenarios:
                 for c in Path("configs/scenarios_zambia").glob("config.*.yaml")
             ],
         ),
-
-
-rule compare_scenarios:
-    """Cross-scenario comparison plots (capacity, generation, demand, spatial maps).
-
-    Run after solving networks:
-        snakemake compare_scenarios
-
-    Or standalone (auto-discovers all results/):
-        python scripts/plot_scenario_comparison.py
-    """
-    params:
-        results_dir="results/",
-        base_dir=".",
-        scenario_filter=["cap_exp_zambia"],
-    output:
-        directory("results/comparison_plots"),
-    log:
-        "logs/compare_scenarios.log",
-    script:
-        "scripts/plot_scenario_comparison.py"

--- a/Snakefile
+++ b/Snakefile
@@ -2440,6 +2440,7 @@ rule compare_scenarios:
     params:
         results_dir="results/",
         base_dir=".",
+        scenario_filter=["cap_exp_zambia"],
     output:
         directory("results/comparison_plots"),
     log:

--- a/configs/validation_dispatch_zambia.yaml
+++ b/configs/validation_dispatch_zambia.yaml
@@ -151,6 +151,27 @@ costs:
     csp-tower: 25
     oil: 30
 
+plotting:
+  scenario_comparison:
+    # Output folder name under results/comparison_plots/ for this comparison group.
+    output_name: "cap_exp_zambia"
+    # Exact run.name values from the scenario configs to compare.
+    # Each string must match a folder name under results/ (i.e. run.name in the
+    # respective config, e.g. run.name: cap_exp_zambia_2025 in cap_exp_zambia.yaml).
+    scenario_filter:
+    - "cap_exp_zambia_2025"
+    - "cap_exp_zambia_2030"
+    - "cap_exp_zambia_2040"
+    - "cap_exp_zambia_2050"
+    label_map:
+      cap_exp_zambia_2025: "cap_exp 2025"
+      cap_exp_zambia_2030: "cap_exp 2030"
+      cap_exp_zambia_2040: "cap_exp 2040"
+      cap_exp_zambia_2050: "cap_exp 2050"
+    # Carriers to hide from all comparison plots; set to [] to show everything.
+    exclude_carriers:
+    - "load shedding"
+
 solving:
   solver:
     name: highs

--- a/configs/validation_dispatch_zambia.yaml
+++ b/configs/validation_dispatch_zambia.yaml
@@ -173,6 +173,7 @@ plotting:
       cap_exp_zambia_2040: "cap_exp 2040"
       cap_exp_zambia_2050: "cap_exp 2050"
     # Carriers to hide from all comparison plots; set to [] to show everything.
+    # (internal model carrier names are used)
     exclude_carriers:
     - "load shedding"
 

--- a/rules/postprocessing.smk
+++ b/rules/postprocessing.smk
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Open Energy Transition gGmbH
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+
+rule compare_scenarios:
+    """Cross-scenario comparison plots (capacity, generation, demand, investments,
+    CO2 emissions and spatial maps).
+
+    The wildcard {scenario_group} is used as both the output folder name and the
+    prefix filter for scenario discovery, so the folder name always matches the
+    scenarios it contains.
+
+    Run for a specific group:
+        snakemake results/comparison_plots/cap_exp_zambia
+
+    Run for multiple groups at once:
+        snakemake results/comparison_plots/cap_exp_zambia results/comparison_plots/validation_dispatch_zambia
+
+    Standalone development usage (from project root):
+        python scripts/plot_scenario_comparison.py
+    """
+    params:
+        results_dir="results/",
+        base_dir=".",
+        scenario_filter=lambda w: [w.scenario_group],
+    output:
+        directory("results/comparison_plots/{scenario_group}"),
+    log:
+        "logs/compare_scenarios_{scenario_group}.log",
+    script:
+        "../scripts/plot_scenario_comparison.py"

--- a/rules/postprocessing.smk
+++ b/rules/postprocessing.smk
@@ -3,26 +3,30 @@
 
 
 rule compare_scenarios:
-    """Cross-scenario comparison plots (capacity, generation, demand, investments,
-    CO2 emissions and spatial maps).
+    """Concrete entry point — resolves {scenario_group} from plotting.scenario_comparison.output_name in config.
 
-    The wildcard {scenario_group} is used as both the output folder name and the
-    prefix filter for scenario discovery, so the folder name always matches the
-    scenarios it contains.
+    Run with:
+        snakemake compare_scenarios
+    """
+    input:
+        expand(
+            "results/comparison_plots/{name}",
+            name=config.get("plotting", {})
+            .get("scenario_comparison", {})
+            .get("output_name", "comparison"),
+        ),
 
-    Run for a specific group:
-        snakemake results/comparison_plots/cap_exp_zambia
 
-    Run for multiple groups at once:
-        snakemake results/comparison_plots/cap_exp_zambia results/comparison_plots/validation_dispatch_zambia
+rule _compare_scenarios_group:
+    """Wildcard rule invoked by compare_scenarios. Can also be called directly with a concrete path:
 
-    Standalone development usage (from project root):
-        python scripts/plot_scenario_comparison.py
+        snakemake results/comparison_plots/<output_name>
+
+    where <output_name> matches plotting.scenario_comparison.output_name in the run config.
+    Scenarios to compare are defined by plotting.scenario_comparison.scenario_filter.
     """
     params:
         results_dir="results/",
-        base_dir=".",
-        scenario_filter=lambda w: [w.scenario_group],
     output:
         directory("results/comparison_plots/{scenario_group}"),
     log:

--- a/scripts/plot_scenario_comparison.py
+++ b/scripts/plot_scenario_comparison.py
@@ -550,7 +550,7 @@ if __name__ == "__main__":
     if "snakemake" not in globals():
         from _helpers import mock_snakemake
 
-        snakemake = mock_snakemake("compare_scenarios")
+        snakemake = mock_snakemake("compare_scenarios", scenario_group="cap_exp_zambia")
 
     configure_logging(snakemake)
 

--- a/scripts/plot_scenario_comparison.py
+++ b/scripts/plot_scenario_comparison.py
@@ -28,11 +28,6 @@ from _helpers import configure_logging, create_logger
 logger = create_logger(__name__)
 
 
-# ---------------------------------------------------------------------------
-# Carrier renaming — names must match keys in config plotting.tech_colors
-# ---------------------------------------------------------------------------
-
-
 def rename_techs(label):
     if label == "hydro":
         return "hydro reservoir"
@@ -76,11 +71,6 @@ preferred_order = pd.Index(
 )
 
 
-# ---------------------------------------------------------------------------
-# Network discovery
-# ---------------------------------------------------------------------------
-
-
 def find_scenario_networks(results_dir):
     """Return {scenario_label: path} for one solved network per scenario run.
 
@@ -119,11 +109,6 @@ def clean_scenario_label(label):
         if label.startswith(pattern):
             return replacement + label[len(pattern) :]
     return label
-
-
-# ---------------------------------------------------------------------------
-# Data extraction
-# ---------------------------------------------------------------------------
 
 
 def extract_capacity(n):
@@ -255,11 +240,6 @@ def build_comparison_dfs(networks):
     return capacity_df, generation_df, investment_df, co2_df, demand_s
 
 
-# ---------------------------------------------------------------------------
-# Plotting
-# ---------------------------------------------------------------------------
-
-
 def _sort_df(df):
     in_pref = df.index.intersection(preferred_order)
     out_pref = df.index.difference(preferred_order)
@@ -338,11 +318,6 @@ def plot_demand_bar(demand_s, output_path):
     fig.savefig(output_path, dpi=150, bbox_inches="tight")
     plt.close(fig)
     logger.info("Saved %s", output_path)
-
-
-# ---------------------------------------------------------------------------
-# Spatial map
-# ---------------------------------------------------------------------------
 
 
 def _bus_generation_by_carrier(n):
@@ -478,11 +453,6 @@ def plot_spatial_map(
     fig.savefig(output_path, dpi=150, bbox_inches="tight")
     plt.close(fig)
     logger.info("Saved %s", output_path)
-
-
-# ---------------------------------------------------------------------------
-# Main orchestration
-# ---------------------------------------------------------------------------
 
 
 def run_comparison(

--- a/scripts/plot_scenario_comparison.py
+++ b/scripts/plot_scenario_comparison.py
@@ -121,8 +121,9 @@ def extract_capacity(n, exclude_carriers=None):
     """Installed optimised capacity by display-name carrier [GW / GWh].
 
     Covers generators, storage units, links and stores. Passive transmission
-    branches (Line) are excluded as their capacity is fixed and not comparable
-    across scenarios. Power components are in MW → GW; energy stores
+    branches (Line) are excluded as their capacity has different physical sense 
+    as compared with generation and storages, and is not comparable
+    with them. Power components are in MW → GW; energy stores
     (e_nom_opt) are in MWh → GWh.
     """
     exclude = set(exclude_carriers or [])

--- a/scripts/plot_scenario_comparison.py
+++ b/scripts/plot_scenario_comparison.py
@@ -71,11 +71,17 @@ preferred_order = pd.Index(
 )
 
 
-def find_scenario_networks(results_dir):
+def find_scenario_networks(results_dir, scenario_filter=None):
     """Return {scenario_label: path} for one solved network per scenario run.
 
     Skips brownfield (_planned) networks and the root-level results/networks/
     folder which belongs to no named run.
+
+    Parameters
+    ----------
+    scenario_filter : list of str, optional
+        If provided, only scenario labels starting with one of these prefixes
+        are included. Pass None to include all discovered scenarios.
     """
     results_dir = os.path.realpath(results_dir)
     networks = {}
@@ -92,6 +98,10 @@ def find_scenario_networks(results_dir):
                 label = os.path.basename(scenario_dir)
             else:
                 label = parent
+            if scenario_filter and not any(
+                label.startswith(p) for p in scenario_filter
+            ):
+                continue
             if label not in networks:
                 networks[label] = nc_path
     return networks
@@ -459,10 +469,11 @@ def run_comparison(
     results_dir,
     output_dir,
     tech_colors,
+    scenario_filter=None,
     country_shapes_path=None,
     bus_regions_path=None,
 ):
-    networks = find_scenario_networks(results_dir)
+    networks = find_scenario_networks(results_dir, scenario_filter=scenario_filter)
     if not networks:
         logger.warning("No .nc network files found under %s", results_dir)
         return
@@ -545,6 +556,7 @@ if __name__ == "__main__":
 
     tech_colors = snakemake.config["plotting"]["tech_colors"]
     results_dir = snakemake.params.results_dir
+    scenario_filter = snakemake.params.get("scenario_filter", None)
 
     country_shapes = os.path.join("resources", "shapes", "country_shapes.geojson")
     bus_regions = os.path.join(
@@ -555,6 +567,7 @@ if __name__ == "__main__":
         results_dir=results_dir,
         output_dir=snakemake.output[0],
         tech_colors=tech_colors,
+        scenario_filter=scenario_filter,
         country_shapes_path=country_shapes,
         bus_regions_path=bus_regions,
     )

--- a/scripts/plot_scenario_comparison.py
+++ b/scripts/plot_scenario_comparison.py
@@ -60,7 +60,7 @@ def carrier_colors(n, tech_colors=None):
     """Dict mapping display name → color.
 
     Primary source: n.carriers.color. For entries that are missing or
-    empty, falls back to tech_colors (from config) keyed first by
+    empty, falls back to tech_colors (from config) keys first by
     display name, then by raw carrier name, then to a neutral grey.
     """
     nice = carrier_nice_names(n)

--- a/scripts/plot_scenario_comparison.py
+++ b/scripts/plot_scenario_comparison.py
@@ -121,7 +121,7 @@ def extract_capacity(n, exclude_carriers=None):
     """Installed optimised capacity by display-name carrier [GW / GWh].
 
     Covers generators, storage units, links and stores. Passive transmission
-    branches (Line) are excluded as their capacity has different physical sense 
+    branches (Line) are excluded as their capacity has different physical sense
     as compared with generation and storages, and is not comparable
     with them. Power components are in MW → GW; energy stores
     (e_nom_opt) are in MWh → GWh.

--- a/scripts/plot_scenario_comparison.py
+++ b/scripts/plot_scenario_comparison.py
@@ -1,0 +1,590 @@
+# SPDX-FileCopyrightText: Open Energy Transition gGmbH
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Cross-scenario comparison plots for PyPSA-Zambia.
+
+Reads solved networks from multiple scenario runs and produces:
+- Stacked bar charts of installed capacity, generation mix and demand
+- Per-scenario spatial maps with generation-mix pie charts at each bus
+
+Outputs go to the directory defined by snakemake.output[0].
+
+Snakemake usage:
+    snakemake compare_scenarios
+
+Standalone development usage (runs mock_snakemake from project root):
+    python scripts/plot_scenario_comparison.py
+"""
+
+import os
+
+import geopandas as gpd
+import matplotlib.patches as mpatches
+import matplotlib.pyplot as plt
+import pandas as pd
+import pypsa
+from _helpers import configure_logging, create_logger
+
+logger = create_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Carrier renaming — names must match keys in config plotting.tech_colors
+# ---------------------------------------------------------------------------
+
+
+def rename_techs(label):
+    if label == "hydro":
+        return "hydro reservoir"
+    elif label == "ror":
+        return "run of river"
+    elif label in ("PHS", "hydro+PHS"):
+        return "hydro reservoir"
+    elif label == "solar":
+        return "solar PV"
+    elif label == "onwind":
+        return "onshore wind"
+    elif label == "offwind-ac":
+        return "offshore wind (AC)"
+    elif label == "offwind-dc":
+        return "offshore wind (DC)"
+    elif "battery" in label:
+        return "battery storage"
+    elif label == "H2":
+        return "hydrogen storage"
+    return label
+
+
+preferred_order = pd.Index(
+    [
+        "hydro reservoir",
+        "run of river",
+        "onshore wind",
+        "offshore wind (AC)",
+        "offshore wind (DC)",
+        "solar PV",
+        "biomass",
+        "geothermal",
+        "nuclear",
+        "coal",
+        "oil",
+        "OCGT",
+        "CCGT",
+        "battery storage",
+        "hydrogen storage",
+    ]
+)
+
+
+# ---------------------------------------------------------------------------
+# Network discovery
+# ---------------------------------------------------------------------------
+
+
+def find_scenario_networks(results_dir):
+    """Return {scenario_label: path} for one solved network per scenario run.
+
+    Skips brownfield (_planned) networks and the root-level results/networks/
+    folder which belongs to no named run.
+    """
+    results_dir = os.path.realpath(results_dir)
+    networks = {}
+    for dirpath, dirnames, filenames in os.walk(results_dir):
+        for fname in sorted(filenames):
+            if not fname.endswith(".nc") or "_planned" in fname:
+                continue
+            nc_path = os.path.join(dirpath, fname)
+            parent = os.path.basename(dirpath)
+            if parent == "networks":
+                scenario_dir = os.path.dirname(dirpath)
+                if os.path.realpath(scenario_dir) == results_dir:
+                    continue
+                label = os.path.basename(scenario_dir)
+            else:
+                label = parent
+            if label not in networks:
+                networks[label] = nc_path
+    return networks
+
+
+def clean_scenario_label(label):
+    """Shorten scenario directory names for plot axis labels."""
+    replacements = [
+        ("cap_exp_zambia_", "CapExp "),
+        ("validation_dispatch_zambia_", "Dispatch "),
+        ("zm_cap_exp", "ZM CapExp"),
+        ("zm_dispatch", "ZM Dispatch"),
+    ]
+    for pattern, replacement in replacements:
+        if label.startswith(pattern):
+            return replacement + label[len(pattern) :]
+    return label
+
+
+# ---------------------------------------------------------------------------
+# Data extraction
+# ---------------------------------------------------------------------------
+
+
+def extract_capacity(n):
+    """Installed optimised capacity by display-name carrier [GW]."""
+    parts = []
+    if not n.generators.empty and "p_nom_opt" in n.generators.columns:
+        parts.append(n.generators.groupby("carrier")["p_nom_opt"].sum())
+    if not n.storage_units.empty and "p_nom_opt" in n.storage_units.columns:
+        parts.append(n.storage_units.groupby("carrier")["p_nom_opt"].sum())
+    if not parts:
+        return pd.Series(dtype=float)
+    result = pd.concat(parts).groupby(level=0).sum()
+    result = result[result > 0]
+    result.index = result.index.map(rename_techs)
+    return result.groupby(level=0).sum() / 1e3  # MW → GW
+
+
+def extract_generation(n):
+    """Annual generation by display-name carrier [TWh]."""
+    w = n.snapshot_weightings.generators
+    parts = []
+    if not n.generators_t.p.empty:
+        gen = (
+            n.generators_t.p.multiply(w, axis=0)
+            .sum()
+            .groupby(n.generators.carrier)
+            .sum()
+        )
+        parts.append(gen)
+    if not n.storage_units_t.p.empty:
+        p_su = n.storage_units_t.p.clip(lower=0)
+        gen_su = p_su.multiply(w, axis=0).sum().groupby(n.storage_units.carrier).sum()
+        parts.append(gen_su)
+    if not parts:
+        return pd.Series(dtype=float)
+    result = pd.concat(parts).groupby(level=0).sum()
+    result = result[result > 0]
+    result.index = result.index.map(rename_techs)
+    return result.groupby(level=0).sum() / 1e6  # MWh → TWh
+
+
+def extract_demand(n):
+    """Total annual electricity demand [TWh]."""
+    if n.loads_t.p.empty:
+        return 0.0
+    w = n.snapshot_weightings.generators
+    return float(n.loads_t.p.clip(lower=0).multiply(w, axis=0).sum().sum()) / 1e6
+
+
+def extract_investments(n):
+    """Annualised capital cost by display-name carrier [EUR million/yr].
+
+    Uses p_nom_opt * capital_cost from generators and storage units.
+    Carriers with zero capital cost (load shedding, export) are excluded.
+    """
+    parts = []
+    if not n.generators.empty and "p_nom_opt" in n.generators.columns:
+        cap = n.generators["capital_cost"] * n.generators["p_nom_opt"]
+        parts.append(cap.groupby(n.generators["carrier"]).sum())
+    if not n.storage_units.empty and "p_nom_opt" in n.storage_units.columns:
+        cap = n.storage_units["capital_cost"] * n.storage_units["p_nom_opt"]
+        parts.append(cap.groupby(n.storage_units["carrier"]).sum())
+    if not parts:
+        return pd.Series(dtype=float)
+    result = pd.concat(parts).groupby(level=0).sum()
+    result = result[result > 0]
+    result.index = result.index.map(rename_techs)
+    return result.groupby(level=0).sum() / 1e6  # EUR → EUR million
+
+
+def extract_co2_emissions(n):
+    """Annual CO2 emissions by display-name carrier [Mt CO2/yr].
+
+    Uses n.carriers.co2_emissions [tCO2/MWh_el] multiplied by
+    annual generation per carrier.
+    """
+    if "co2_emissions" not in n.carriers.columns:
+        return pd.Series(dtype=float)
+    w = n.snapshot_weightings.generators
+    emission_factors = n.carriers["co2_emissions"]
+
+    parts = []
+    if not n.generators_t.p.empty:
+        gen = (
+            n.generators_t.p.multiply(w, axis=0)
+            .sum()
+            .groupby(n.generators["carrier"])
+            .sum()
+        )
+        co2 = gen * gen.index.map(emission_factors)
+        parts.append(co2)
+
+    if not parts:
+        return pd.Series(dtype=float)
+
+    result = pd.concat(parts).groupby(level=0).sum()
+    result = result[result > 0]
+    result.index = result.index.map(rename_techs)
+    return result.groupby(level=0).sum() / 1e6  # tCO2 → Mt CO2
+
+
+def build_comparison_dfs(networks):
+    """Load each network; return comparison DataFrames for all metrics."""
+    capacity_cols = {}
+    generation_cols = {}
+    investment_cols = {}
+    co2_cols = {}
+    demand_vals = {}
+
+    for label, path in networks.items():
+        logger.info("Loading %s: %s", label, path)
+        try:
+            n = pypsa.Network(path)
+        except Exception as e:
+            logger.warning("Skipping %s: %s", label, e)
+            continue
+        short = clean_scenario_label(label)
+        capacity_cols[short] = extract_capacity(n)
+        generation_cols[short] = extract_generation(n)
+        investment_cols[short] = extract_investments(n)
+        co2_cols[short] = extract_co2_emissions(n)
+        demand_vals[short] = extract_demand(n)
+
+    capacity_df = pd.DataFrame(capacity_cols).fillna(0)
+    generation_df = pd.DataFrame(generation_cols).fillna(0)
+    investment_df = pd.DataFrame(investment_cols).fillna(0)
+    co2_df = pd.DataFrame(co2_cols).fillna(0)
+    demand_s = pd.Series(demand_vals)
+    return capacity_df, generation_df, investment_df, co2_df, demand_s
+
+
+# ---------------------------------------------------------------------------
+# Plotting
+# ---------------------------------------------------------------------------
+
+
+def _sort_df(df):
+    in_pref = df.index.intersection(preferred_order)
+    out_pref = df.index.difference(preferred_order)
+    return df.loc[in_pref.tolist() + out_pref.tolist()]
+
+
+def _get_color(tech, tech_colors):
+    return tech_colors.get(tech, tech_colors.get(rename_techs(tech), "#aaaaaa"))
+
+
+def plot_stacked_bar(df, ylabel, title, tech_colors, output_path, threshold=0.01):
+    """Stacked bar chart with one bar per scenario (column)."""
+    df = _sort_df(df.copy())
+    df = df[df.max(axis=1) >= threshold]
+    if df.empty:
+        logger.warning("No data above threshold for: %s", title)
+        return
+
+    colors = [_get_color(t, tech_colors) for t in df.index]
+    n_scenarios = len(df.columns)
+
+    fig, ax = plt.subplots(figsize=(max(8, n_scenarios * 1.6), 7))
+    df.T.plot(
+        kind="bar",
+        stacked=True,
+        ax=ax,
+        color=colors,
+        width=0.6,
+        edgecolor="white",
+        linewidth=0.4,
+    )
+
+    handles, labels = ax.get_legend_handles_labels()
+    ax.legend(
+        handles[::-1],
+        labels[::-1],
+        ncol=1,
+        loc="upper left",
+        bbox_to_anchor=(1.01, 1),
+        fontsize=9,
+        frameon=True,
+    )
+    ax.set_ylabel(ylabel, fontsize=11)
+    ax.set_title(title, fontsize=13, pad=10)
+    ax.set_xlabel("")
+    ax.tick_params(axis="x", rotation=30)
+    ax.grid(axis="y", alpha=0.4)
+    ax.spines["top"].set_visible(False)
+    ax.spines["right"].set_visible(False)
+
+    fig.tight_layout()
+    os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
+    fig.savefig(output_path, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+    logger.info("Saved %s", output_path)
+
+
+def plot_demand_bar(demand_s, output_path):
+    """Simple bar chart of total annual demand per scenario."""
+    if demand_s.empty or demand_s.sum() == 0:
+        return
+    fig, ax = plt.subplots(figsize=(max(6, len(demand_s) * 1.4), 5))
+    bars = ax.bar(
+        demand_s.index, demand_s.values, color="#110d63", width=0.5, edgecolor="white"
+    )
+    ax.bar_label(bars, fmt="%.1f", padding=3, fontsize=9)
+    ax.set_ylabel("Annual demand [TWh]", fontsize=11)
+    ax.set_title("Total Electricity Demand by Scenario", fontsize=13, pad=10)
+    ax.set_xlabel("")
+    ax.tick_params(axis="x", rotation=30)
+    ax.grid(axis="y", alpha=0.4)
+    ax.spines["top"].set_visible(False)
+    ax.spines["right"].set_visible(False)
+    fig.tight_layout()
+    os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
+    fig.savefig(output_path, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+    logger.info("Saved %s", output_path)
+
+
+# ---------------------------------------------------------------------------
+# Spatial map
+# ---------------------------------------------------------------------------
+
+
+def _bus_generation_by_carrier(n):
+    """DataFrame[bus x display-carrier] of annual generation [GWh]."""
+    w = n.snapshot_weightings.generators
+    parts = []
+
+    if not n.generators_t.p.empty:
+        gen = n.generators_t.p.multiply(w, axis=0).sum()
+        meta = n.generators[["carrier", "bus"]].copy()
+        meta["gen"] = gen
+        pivot = (
+            meta[meta["gen"] > 0]
+            .groupby(["bus", "carrier"])["gen"]
+            .sum()
+            .unstack(fill_value=0)
+        )
+        pivot.columns = pivot.columns.map(rename_techs)
+        pivot = pivot.T.groupby(level=0).sum().T
+        parts.append(pivot)
+
+    if not n.storage_units_t.p.empty:
+        p = n.storage_units_t.p.clip(lower=0)
+        gen = p.multiply(w, axis=0).sum()
+        meta = n.storage_units[["carrier", "bus"]].copy()
+        meta["gen"] = gen
+        pivot = (
+            meta[meta["gen"] > 0]
+            .groupby(["bus", "carrier"])["gen"]
+            .sum()
+            .unstack(fill_value=0)
+        )
+        pivot.columns = pivot.columns.map(rename_techs)
+        pivot = pivot.T.groupby(level=0).sum().T
+        parts.append(pivot)
+
+    if not parts:
+        return pd.DataFrame()
+    return pd.concat(parts, axis=0).fillna(0).groupby(level=0).sum() / 1e3
+
+
+def plot_spatial_map(
+    n, label, tech_colors, output_path, country_shapes_path=None, bus_regions_path=None
+):
+    """Geographic map with generation-mix pie charts at each bus.
+
+    Pie-chart radius is proportional to total installed capacity.
+    """
+    buses = n.buses[n.buses.carrier == "AC"].copy()
+    if buses.empty:
+        buses = n.buses.copy()
+
+    bus_gen = _bus_generation_by_carrier(n)
+    if bus_gen.empty:
+        logger.warning("No generation data for spatial map of %s", label)
+        return
+
+    # Capacity per bus for sizing pie charts
+    bus_cap = pd.Series(0.0, index=buses.index)
+    if not n.generators.empty and "p_nom_opt" in n.generators.columns:
+        g = n.generators[n.generators["bus"].isin(buses.index)]
+        bus_cap = bus_cap.add(g.groupby("bus")["p_nom_opt"].sum() / 1e3, fill_value=0)
+    if not n.storage_units.empty and "p_nom_opt" in n.storage_units.columns:
+        su = n.storage_units[n.storage_units["bus"].isin(buses.index)]
+        bus_cap = bus_cap.add(su.groupby("bus")["p_nom_opt"].sum() / 1e3, fill_value=0)
+
+    fig, ax = plt.subplots(figsize=(10, 9))
+
+    # Background outline
+    if country_shapes_path and os.path.exists(country_shapes_path):
+        gpd.read_file(country_shapes_path).boundary.plot(
+            ax=ax, color="gray", linewidth=0.8, zorder=1
+        )
+    elif bus_regions_path and os.path.exists(bus_regions_path):
+        gpd.read_file(bus_regions_path).boundary.plot(
+            ax=ax, color="lightgray", linewidth=0.5, zorder=1
+        )
+
+    # Transmission lines
+    for _, line in n.lines.iterrows():
+        b0, b1 = line.get("bus0"), line.get("bus1")
+        if b0 in buses.index and b1 in buses.index:
+            x0, y0 = buses.loc[b0, ["x", "y"]]
+            x1, y1 = buses.loc[b1, ["x", "y"]]
+            ax.plot(
+                [x0, x1], [y0, y1], color="#70af1d", linewidth=0.8, zorder=2, alpha=0.7
+            )
+
+    # Order carriers for consistent pie slices
+    carriers_all = [c for c in preferred_order if c in bus_gen.columns]
+    carriers_all += [c for c in bus_gen.columns if c not in preferred_order]
+
+    max_cap = bus_cap.max() if bus_cap.max() > 0 else 1.0
+    pie_scale = 1.5  # max pie radius in degrees
+
+    for bus_id, bus_row in buses.iterrows():
+        if bus_id not in bus_gen.index:
+            continue
+        gen_row = bus_gen.loc[bus_id, [c for c in carriers_all if c in bus_gen.columns]]
+        if gen_row.sum() == 0:
+            continue
+        cap = bus_cap.get(bus_id, 0)
+        radius = pie_scale * (cap / max_cap) ** 0.5
+        x, y = bus_row["x"], bus_row["y"]
+        inset = ax.inset_axes(
+            [x - radius, y - radius, 2 * radius, 2 * radius],
+            transform=ax.transData,
+        )
+        inset.pie(
+            gen_row.values,
+            colors=[_get_color(c, tech_colors) for c in gen_row.index],
+            startangle=90,
+        )
+        inset.set_aspect("equal")
+
+    # Carrier legend
+    legend_carriers = [c for c in carriers_all if c in bus_gen.columns]
+    patches = [
+        mpatches.Patch(color=_get_color(c, tech_colors), label=c)
+        for c in legend_carriers
+    ]
+    ax.legend(handles=patches, loc="lower left", fontsize=8, ncol=2, framealpha=0.9)
+
+    ax.set_xlim(buses["x"].min() - 2, buses["x"].max() + 2)
+    ax.set_ylim(buses["y"].min() - 2, buses["y"].max() + 2)
+    ax.set_title("Generation Mix — {}".format(label), fontsize=13, pad=10)
+    ax.set_xlabel("Longitude", fontsize=9)
+    ax.set_ylabel("Latitude", fontsize=9)
+    ax.grid(alpha=0.2)
+
+    fig.tight_layout()
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    fig.savefig(output_path, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+    logger.info("Saved %s", output_path)
+
+
+# ---------------------------------------------------------------------------
+# Main orchestration
+# ---------------------------------------------------------------------------
+
+
+def run_comparison(
+    results_dir,
+    output_dir,
+    tech_colors,
+    country_shapes_path=None,
+    bus_regions_path=None,
+):
+    networks = find_scenario_networks(results_dir)
+    if not networks:
+        logger.warning("No .nc network files found under %s", results_dir)
+        return
+
+    logger.info("Found %d scenarios: %s", len(networks), list(networks.keys()))
+    os.makedirs(output_dir, exist_ok=True)
+
+    capacity_df, generation_df, investment_df, co2_df, demand_s = build_comparison_dfs(
+        networks
+    )
+
+    if not capacity_df.empty:
+        plot_stacked_bar(
+            capacity_df,
+            ylabel="Installed capacity [GW]",
+            title="Installed Capacity by Scenario",
+            tech_colors=tech_colors,
+            output_path=os.path.join(output_dir, "installed_capacity.png"),
+        )
+
+    if not generation_df.empty:
+        plot_stacked_bar(
+            generation_df,
+            ylabel="Annual generation [TWh]",
+            title="Generation Mix by Scenario",
+            tech_colors=tech_colors,
+            output_path=os.path.join(output_dir, "generation_mix.png"),
+        )
+
+    if not investment_df.empty:
+        plot_stacked_bar(
+            investment_df,
+            ylabel="Annualised capital cost [EUR million/yr]",
+            title="Investments by Scenario",
+            tech_colors=tech_colors,
+            output_path=os.path.join(output_dir, "investments.png"),
+        )
+
+    if not co2_df.empty:
+        plot_stacked_bar(
+            co2_df,
+            ylabel="Annual CO₂ emissions [Mt CO₂/yr]",
+            title="Carbon Emissions by Scenario",
+            tech_colors=tech_colors,
+            output_path=os.path.join(output_dir, "co2_emissions.png"),
+            threshold=0.001,
+        )
+
+    if not demand_s.empty:
+        plot_demand_bar(demand_s, os.path.join(output_dir, "demand.png"))
+
+    spatial_dir = os.path.join(output_dir, "spatial")
+    for label, path in networks.items():
+        try:
+            n = pypsa.Network(path)
+        except Exception as e:
+            logger.warning("Skipping spatial map for %s: %s", label, e)
+            continue
+        short = clean_scenario_label(label)
+        safe = short.replace(" ", "_").replace("/", "_")
+        plot_spatial_map(
+            n,
+            label=short,
+            tech_colors=tech_colors,
+            output_path=os.path.join(spatial_dir, "{}_spatial.png".format(safe)),
+            country_shapes_path=country_shapes_path,
+            bus_regions_path=bus_regions_path,
+        )
+
+    logger.info("All comparison plots saved to %s", output_dir)
+
+
+if __name__ == "__main__":
+    if "snakemake" not in globals():
+        from _helpers import mock_snakemake
+
+        snakemake = mock_snakemake("compare_scenarios")
+
+    configure_logging(snakemake)
+
+    tech_colors = snakemake.config["plotting"]["tech_colors"]
+    results_dir = snakemake.params.results_dir
+
+    country_shapes = os.path.join("resources", "shapes", "country_shapes.geojson")
+    bus_regions = os.path.join(
+        "resources", "bus_regions", "regions_onshore_elec_s_10.geojson"
+    )
+
+    run_comparison(
+        results_dir=results_dir,
+        output_dir=snakemake.output[0],
+        tech_colors=tech_colors,
+        country_shapes_path=country_shapes,
+        bus_regions_path=bus_regions,
+    )

--- a/scripts/plot_scenario_comparison.py
+++ b/scripts/plot_scenario_comparison.py
@@ -3,230 +3,217 @@
 
 """Cross-scenario comparison plots for PyPSA-Zambia.
 
-Reads solved networks from multiple scenario runs and produces:
-- Stacked bar charts of installed capacity, generation mix and demand
-- Per-scenario spatial maps with generation-mix pie charts at each bus
+Reads solved networks from multiple scenario runs and produces stacked bar
+charts of installed capacity, generation mix, demand, investments and CO2
+emissions for side-by-side scenario comparison.
 
 Outputs go to the directory defined by snakemake.output[0].
-
-Snakemake usage:
-    snakemake compare_scenarios
-
-Standalone development usage (runs mock_snakemake from project root):
-    python scripts/plot_scenario_comparison.py
 """
 
 import os
 
-import geopandas as gpd
-import matplotlib.patches as mpatches
 import matplotlib.pyplot as plt
 import pandas as pd
 import pypsa
 from _helpers import configure_logging, create_logger
+from pypsa.statistics import get_carrier
 
 logger = create_logger(__name__)
 
-
-def rename_techs(label):
-    if label == "hydro":
-        return "hydro reservoir"
-    elif label == "ror":
-        return "run of river"
-    elif label in ("PHS", "hydro+PHS"):
-        return "hydro reservoir"
-    elif label == "solar":
-        return "solar PV"
-    elif label == "onwind":
-        return "onshore wind"
-    elif label == "offwind-ac":
-        return "offshore wind (AC)"
-    elif label == "offwind-dc":
-        return "offshore wind (DC)"
-    elif "battery" in label:
-        return "battery storage"
-    elif label == "H2":
-        return "hydrogen storage"
-    return label
-
-
+# Preferred stack order uses n.carriers.nice_name values.
+# Carriers not listed here are appended at the end.
 preferred_order = pd.Index(
     [
-        "hydro reservoir",
-        "run of river",
-        "onshore wind",
-        "offshore wind (AC)",
-        "offshore wind (DC)",
-        "solar PV",
-        "biomass",
-        "geothermal",
-        "nuclear",
-        "coal",
-        "oil",
-        "OCGT",
-        "CCGT",
-        "battery storage",
-        "hydrogen storage",
+        "Reservoir & Dam",
+        "Run of River",
+        "Pumped Hydro Storage",
+        "Onshore Wind",
+        "Offshore Wind (AC)",
+        "Offshore Wind (DC)",
+        "Solar",
+        "Biomass",
+        "Geothermal",
+        "Nuclear",
+        "Coal",
+        "Oil",
+        "Open-Cycle Gas",
+        "Combined-Cycle Gas",
+        "Battery Storage",
+        "Hydrogen Storage",
     ]
 )
 
 
-def find_scenario_networks(results_dir, scenario_filter=None):
-    """Return {scenario_label: path} for one solved network per scenario run.
+def carrier_nice_names(n):
+    """Series mapping raw carrier name → display name.
 
-    Skips brownfield (_planned) networks and the root-level results/networks/
-    folder which belongs to no named run.
+    Uses n.carriers.nice_name; falls back to the carrier name itself for
+    entries that are missing or empty (e.g. custom or local carriers).
+    """
+    names = n.carriers["nice_name"].copy()
+    missing = names.isna() | (names.str.strip() == "")
+    names[missing] = names.index[missing]
+    return names
 
-    Parameters
-    ----------
-    scenario_filter : list of str, optional
-        If provided, only scenario labels starting with one of these prefixes
-        are included. Pass None to include all discovered scenarios.
+
+def carrier_colors(n, tech_colors=None):
+    """Dict mapping display name → color.
+
+    Primary source: n.carriers.color. For entries that are missing or
+    empty, falls back to tech_colors (from config) keyed first by
+    display name, then by raw carrier name, then to a neutral grey.
+    """
+    nice = carrier_nice_names(n)
+    result = {}
+    for carrier in n.carriers.index:
+        display = nice[carrier]
+        color = n.carriers.at[carrier, "color"]
+        if not color or str(color).strip() == "":
+            fallback = tech_colors or {}
+            color = fallback.get(display) or fallback.get(carrier) or "#aaaaaa"
+        result[display] = color
+    return result
+
+
+def find_scenario_networks(results_dir, scenario_filter):
+    """Return {scenario_label: path} for each run name in scenario_filter.
+
+    scenario_filter is a list of exact run.name values (folder names under
+    results/). Only folders whose name exactly matches an entry are included;
     """
     results_dir = os.path.realpath(results_dir)
     networks = {}
     for dirpath, dirnames, filenames in os.walk(results_dir):
         for fname in sorted(filenames):
-            if not fname.endswith(".nc") or "_planned" in fname:
+            if not fname.endswith(".nc"):
                 continue
             nc_path = os.path.join(dirpath, fname)
             parent = os.path.basename(dirpath)
+            # Networks live at <scenario>/networks/*.nc; step up one level to
+            # get the scenario folder name. Otherwise use the parent directly.
             if parent == "networks":
-                scenario_dir = os.path.dirname(dirpath)
-                if os.path.realpath(scenario_dir) == results_dir:
-                    continue
-                label = os.path.basename(scenario_dir)
+                label = os.path.basename(os.path.dirname(dirpath))
             else:
                 label = parent
-            if scenario_filter and not any(
-                label.startswith(p) for p in scenario_filter
-            ):
+            if label not in scenario_filter:
                 continue
             if label not in networks:
                 networks[label] = nc_path
     return networks
 
 
-def clean_scenario_label(label):
-    """Shorten scenario directory names for plot axis labels."""
-    replacements = [
-        ("cap_exp_zambia_", "CapExp "),
-        ("validation_dispatch_zambia_", "Dispatch "),
-        ("zm_cap_exp", "ZM CapExp"),
-        ("zm_dispatch", "ZM Dispatch"),
-    ]
-    for pattern, replacement in replacements:
-        if label.startswith(pattern):
-            return replacement + label[len(pattern) :]
-    return label
+def clean_scenario_label(label, label_map=None):
+    """Return a display label for a scenario folder name.
+
+    label_map is a dict mapping raw folder names to display strings
+    (set via plotting.scenario_comparison.label_map in the run config).
+    The raw folder name is returned unchanged when no entry exists.
+    """
+    return (label_map or {}).get(label, label)
 
 
-def extract_capacity(n):
-    """Installed optimised capacity by display-name carrier [GW]."""
-    parts = []
-    if not n.generators.empty and "p_nom_opt" in n.generators.columns:
-        parts.append(n.generators.groupby("carrier")["p_nom_opt"].sum())
-    if not n.storage_units.empty and "p_nom_opt" in n.storage_units.columns:
-        parts.append(n.storage_units.groupby("carrier")["p_nom_opt"].sum())
-    if not parts:
-        return pd.Series(dtype=float)
-    result = pd.concat(parts).groupby(level=0).sum()
-    result = result[result > 0]
-    result.index = result.index.map(rename_techs)
-    return result.groupby(level=0).sum() / 1e3  # MW → GW
+def _by_carrier(s, exclude):
+    """Aggregate a (component, carrier) statistics Series to carrier level."""
+    return s.groupby(level="carrier").sum().pipe(lambda x: x[~x.index.isin(exclude)])
 
 
-def extract_generation(n):
-    """Annual generation by display-name carrier [TWh]."""
-    w = n.snapshot_weightings.generators
-    parts = []
-    if not n.generators_t.p.empty:
-        gen = (
-            n.generators_t.p.multiply(w, axis=0)
-            .sum()
-            .groupby(n.generators.carrier)
-            .sum()
-        )
-        parts.append(gen)
-    if not n.storage_units_t.p.empty:
-        p_su = n.storage_units_t.p.clip(lower=0)
-        gen_su = p_su.multiply(w, axis=0).sum().groupby(n.storage_units.carrier).sum()
-        parts.append(gen_su)
-    if not parts:
-        return pd.Series(dtype=float)
-    result = pd.concat(parts).groupby(level=0).sum()
-    result = result[result > 0]
-    result.index = result.index.map(rename_techs)
-    return result.groupby(level=0).sum() / 1e6  # MWh → TWh
+def extract_capacity(n, exclude_carriers=None):
+    """Installed optimised capacity by display-name carrier [GW / GWh].
+
+    Covers generators, storage units, links and stores. Passive transmission
+    branches (Line) are excluded as their capacity is fixed and not comparable
+    across scenarios. Power components are in MW → GW; energy stores
+    (e_nom_opt) are in MWh → GWh.
+    """
+    exclude = set(exclude_carriers or [])
+    nice = carrier_nice_names(n)
+    result = _by_carrier(
+        n.statistics.optimal_capacity(groupby=get_carrier, nice_names=False).drop(
+            "Line", level="component", errors="ignore"
+        ),
+        exclude,
+    )
+    result.index = result.index.map(nice)
+    return result.groupby(level=0).sum() / 1e3
+
+
+def extract_generation(n, exclude_carriers=None):
+    """Annual net generation by display-name carrier [TWh].
+
+    n.statistics.energy_balance gives net bus injections (positive = supply,
+    negative = withdrawal) with correct sign conventions for all component
+    types. Load is dropped so only the supply side remains.
+    """
+    exclude = set(exclude_carriers or [])
+    nice = carrier_nice_names(n)
+    result = _by_carrier(
+        n.statistics.energy_balance(groupby=get_carrier, nice_names=False).drop(
+            "Load", level="component", errors="ignore"
+        ),
+        exclude,
+    )
+    result.index = result.index.map(nice)
+    return result.groupby(level=0).sum() / 1e6
 
 
 def extract_demand(n):
     """Total annual electricity demand [TWh]."""
-    if n.loads_t.p.empty:
-        return 0.0
-    w = n.snapshot_weightings.generators
-    return float(n.loads_t.p.clip(lower=0).multiply(w, axis=0).sum().sum()) / 1e6
+    return (
+        float(
+            n.statistics.withdrawal(
+                comps=["Load"], groupby=get_carrier, nice_names=False
+            ).sum()
+        )
+        / 1e6
+    )
 
 
-def extract_investments(n):
-    """Annualised capital cost by display-name carrier [EUR million/yr].
-
-    Uses p_nom_opt * capital_cost from generators and storage units.
-    Carriers with zero capital cost (load shedding, export) are excluded.
-    """
-    parts = []
-    if not n.generators.empty and "p_nom_opt" in n.generators.columns:
-        cap = n.generators["capital_cost"] * n.generators["p_nom_opt"]
-        parts.append(cap.groupby(n.generators["carrier"]).sum())
-    if not n.storage_units.empty and "p_nom_opt" in n.storage_units.columns:
-        cap = n.storage_units["capital_cost"] * n.storage_units["p_nom_opt"]
-        parts.append(cap.groupby(n.storage_units["carrier"]).sum())
-    if not parts:
-        return pd.Series(dtype=float)
-    result = pd.concat(parts).groupby(level=0).sum()
-    result = result[result > 0]
-    result.index = result.index.map(rename_techs)
-    return result.groupby(level=0).sum() / 1e6  # EUR → EUR million
+def extract_investments(n, exclude_carriers=None):
+    """Annualised capital cost by display-name carrier [EUR million/yr]."""
+    exclude = set(exclude_carriers or [])
+    nice = carrier_nice_names(n)
+    result = _by_carrier(
+        n.statistics.capex(groupby=get_carrier, nice_names=False).drop(
+            "Line", level="component", errors="ignore"
+        ),
+        exclude,
+    )
+    result.index = result.index.map(nice)
+    return result.groupby(level=0).sum() / 1e6
 
 
-def extract_co2_emissions(n):
-    """Annual CO2 emissions by display-name carrier [Mt CO2/yr].
-
-    Uses n.carriers.co2_emissions [tCO2/MWh_el] multiplied by
-    annual generation per carrier.
-    """
+def extract_co2_emissions(n, exclude_carriers=None):
+    """Annual CO2 emissions by display-name carrier [Mt CO2/yr]."""
     if "co2_emissions" not in n.carriers.columns:
         return pd.Series(dtype=float)
-    w = n.snapshot_weightings.generators
-    emission_factors = n.carriers["co2_emissions"]
-
-    parts = []
-    if not n.generators_t.p.empty:
-        gen = (
-            n.generators_t.p.multiply(w, axis=0)
-            .sum()
-            .groupby(n.generators["carrier"])
-            .sum()
-        )
-        co2 = gen * gen.index.map(emission_factors)
-        parts.append(co2)
-
-    if not parts:
-        return pd.Series(dtype=float)
-
-    result = pd.concat(parts).groupby(level=0).sum()
-    result = result[result > 0]
-    result.index = result.index.map(rename_techs)
-    return result.groupby(level=0).sum() / 1e6  # tCO2 → Mt CO2
+    exclude = set(exclude_carriers or [])
+    nice = carrier_nice_names(n)
+    ef = n.carriers["co2_emissions"]
+    gen = _by_carrier(
+        n.statistics.supply(groupby=get_carrier, nice_names=False).drop(
+            ["Line", "Link"], level="component", errors="ignore"
+        ),
+        exclude,
+    )
+    result = (gen * gen.index.map(ef)).dropna()
+    result.index = result.index.map(nice)
+    return result.groupby(level=0).sum() / 1e6
 
 
-def build_comparison_dfs(networks):
-    """Load each network; return comparison DataFrames for all metrics."""
+def build_comparison_dfs(
+    networks, tech_colors=None, label_map=None, exclude_carriers=None
+):
+    """Load each network; return comparison DataFrames and a merged color dict.
+
+    Colors are derived from n.carriers.color with tech_colors as fallback
+    for any carrier whose color is missing or empty.
+    """
     capacity_cols = {}
     generation_cols = {}
     investment_cols = {}
     co2_cols = {}
     demand_vals = {}
+    display_colors = {}
 
     for label, path in networks.items():
         logger.info("Loading %s: %s", label, path)
@@ -235,32 +222,33 @@ def build_comparison_dfs(networks):
         except Exception as e:
             logger.warning("Skipping %s: %s", label, e)
             continue
-        short = clean_scenario_label(label)
-        capacity_cols[short] = extract_capacity(n)
-        generation_cols[short] = extract_generation(n)
-        investment_cols[short] = extract_investments(n)
-        co2_cols[short] = extract_co2_emissions(n)
+        short = clean_scenario_label(label, label_map=label_map)
+        capacity_cols[short] = extract_capacity(n, exclude_carriers=exclude_carriers)
+        generation_cols[short] = extract_generation(
+            n, exclude_carriers=exclude_carriers
+        )
+        investment_cols[short] = extract_investments(
+            n, exclude_carriers=exclude_carriers
+        )
+        co2_cols[short] = extract_co2_emissions(n, exclude_carriers=exclude_carriers)
         demand_vals[short] = extract_demand(n)
+        display_colors.update(carrier_colors(n, tech_colors))
 
     capacity_df = pd.DataFrame(capacity_cols).fillna(0)
     generation_df = pd.DataFrame(generation_cols).fillna(0)
     investment_df = pd.DataFrame(investment_cols).fillna(0)
     co2_df = pd.DataFrame(co2_cols).fillna(0)
     demand_s = pd.Series(demand_vals)
-    return capacity_df, generation_df, investment_df, co2_df, demand_s
+    return capacity_df, generation_df, investment_df, co2_df, demand_s, display_colors
 
 
 def _sort_df(df):
-    in_pref = df.index.intersection(preferred_order)
-    out_pref = df.index.difference(preferred_order)
-    return df.loc[in_pref.tolist() + out_pref.tolist()]
+    in_pref = [c for c in preferred_order if c in df.index]
+    out_pref = [c for c in df.index if c not in preferred_order]
+    return df.loc[in_pref + out_pref]
 
 
-def _get_color(tech, tech_colors):
-    return tech_colors.get(tech, tech_colors.get(rename_techs(tech), "#aaaaaa"))
-
-
-def plot_stacked_bar(df, ylabel, title, tech_colors, output_path, threshold=0.01):
+def plot_stacked_bar(df, ylabel, title, display_colors, output_path, threshold=0.01):
     """Stacked bar chart with one bar per scenario (column)."""
     df = _sort_df(df.copy())
     df = df[df.max(axis=1) >= threshold]
@@ -268,7 +256,7 @@ def plot_stacked_bar(df, ylabel, title, tech_colors, output_path, threshold=0.01
         logger.warning("No data above threshold for: %s", title)
         return
 
-    colors = [_get_color(t, tech_colors) for t in df.index]
+    colors = [display_colors.get(t, "#aaaaaa") for t in df.index]
     n_scenarios = len(df.columns)
 
     fig, ax = plt.subplots(figsize=(max(8, n_scenarios * 1.6), 7))
@@ -330,150 +318,15 @@ def plot_demand_bar(demand_s, output_path):
     logger.info("Saved %s", output_path)
 
 
-def _bus_generation_by_carrier(n):
-    """DataFrame[bus x display-carrier] of annual generation [GWh]."""
-    w = n.snapshot_weightings.generators
-    parts = []
-
-    if not n.generators_t.p.empty:
-        gen = n.generators_t.p.multiply(w, axis=0).sum()
-        meta = n.generators[["carrier", "bus"]].copy()
-        meta["gen"] = gen
-        pivot = (
-            meta[meta["gen"] > 0]
-            .groupby(["bus", "carrier"])["gen"]
-            .sum()
-            .unstack(fill_value=0)
-        )
-        pivot.columns = pivot.columns.map(rename_techs)
-        pivot = pivot.T.groupby(level=0).sum().T
-        parts.append(pivot)
-
-    if not n.storage_units_t.p.empty:
-        p = n.storage_units_t.p.clip(lower=0)
-        gen = p.multiply(w, axis=0).sum()
-        meta = n.storage_units[["carrier", "bus"]].copy()
-        meta["gen"] = gen
-        pivot = (
-            meta[meta["gen"] > 0]
-            .groupby(["bus", "carrier"])["gen"]
-            .sum()
-            .unstack(fill_value=0)
-        )
-        pivot.columns = pivot.columns.map(rename_techs)
-        pivot = pivot.T.groupby(level=0).sum().T
-        parts.append(pivot)
-
-    if not parts:
-        return pd.DataFrame()
-    return pd.concat(parts, axis=0).fillna(0).groupby(level=0).sum() / 1e3
-
-
-def plot_spatial_map(
-    n, label, tech_colors, output_path, country_shapes_path=None, bus_regions_path=None
-):
-    """Geographic map with generation-mix pie charts at each bus.
-
-    Pie-chart radius is proportional to total installed capacity.
-    """
-    buses = n.buses[n.buses.carrier == "AC"].copy()
-    if buses.empty:
-        buses = n.buses.copy()
-
-    bus_gen = _bus_generation_by_carrier(n)
-    if bus_gen.empty:
-        logger.warning("No generation data for spatial map of %s", label)
-        return
-
-    # Capacity per bus for sizing pie charts
-    bus_cap = pd.Series(0.0, index=buses.index)
-    if not n.generators.empty and "p_nom_opt" in n.generators.columns:
-        g = n.generators[n.generators["bus"].isin(buses.index)]
-        bus_cap = bus_cap.add(g.groupby("bus")["p_nom_opt"].sum() / 1e3, fill_value=0)
-    if not n.storage_units.empty and "p_nom_opt" in n.storage_units.columns:
-        su = n.storage_units[n.storage_units["bus"].isin(buses.index)]
-        bus_cap = bus_cap.add(su.groupby("bus")["p_nom_opt"].sum() / 1e3, fill_value=0)
-
-    fig, ax = plt.subplots(figsize=(10, 9))
-
-    # Background outline
-    if country_shapes_path and os.path.exists(country_shapes_path):
-        gpd.read_file(country_shapes_path).boundary.plot(
-            ax=ax, color="gray", linewidth=0.8, zorder=1
-        )
-    elif bus_regions_path and os.path.exists(bus_regions_path):
-        gpd.read_file(bus_regions_path).boundary.plot(
-            ax=ax, color="lightgray", linewidth=0.5, zorder=1
-        )
-
-    # Transmission lines
-    for _, line in n.lines.iterrows():
-        b0, b1 = line.get("bus0"), line.get("bus1")
-        if b0 in buses.index and b1 in buses.index:
-            x0, y0 = buses.loc[b0, ["x", "y"]]
-            x1, y1 = buses.loc[b1, ["x", "y"]]
-            ax.plot(
-                [x0, x1], [y0, y1], color="#70af1d", linewidth=0.8, zorder=2, alpha=0.7
-            )
-
-    # Order carriers for consistent pie slices
-    carriers_all = [c for c in preferred_order if c in bus_gen.columns]
-    carriers_all += [c for c in bus_gen.columns if c not in preferred_order]
-
-    max_cap = bus_cap.max() if bus_cap.max() > 0 else 1.0
-    pie_scale = 1.5  # max pie radius in degrees
-
-    for bus_id, bus_row in buses.iterrows():
-        if bus_id not in bus_gen.index:
-            continue
-        gen_row = bus_gen.loc[bus_id, [c for c in carriers_all if c in bus_gen.columns]]
-        if gen_row.sum() == 0:
-            continue
-        cap = bus_cap.get(bus_id, 0)
-        radius = pie_scale * (cap / max_cap) ** 0.5
-        x, y = bus_row["x"], bus_row["y"]
-        inset = ax.inset_axes(
-            [x - radius, y - radius, 2 * radius, 2 * radius],
-            transform=ax.transData,
-        )
-        inset.pie(
-            gen_row.values,
-            colors=[_get_color(c, tech_colors) for c in gen_row.index],
-            startangle=90,
-        )
-        inset.set_aspect("equal")
-
-    # Carrier legend
-    legend_carriers = [c for c in carriers_all if c in bus_gen.columns]
-    patches = [
-        mpatches.Patch(color=_get_color(c, tech_colors), label=c)
-        for c in legend_carriers
-    ]
-    ax.legend(handles=patches, loc="lower left", fontsize=8, ncol=2, framealpha=0.9)
-
-    ax.set_xlim(buses["x"].min() - 2, buses["x"].max() + 2)
-    ax.set_ylim(buses["y"].min() - 2, buses["y"].max() + 2)
-    ax.set_title("Generation Mix — {}".format(label), fontsize=13, pad=10)
-    ax.set_xlabel("Longitude", fontsize=9)
-    ax.set_ylabel("Latitude", fontsize=9)
-    ax.grid(alpha=0.2)
-
-    fig.tight_layout()
-    os.makedirs(os.path.dirname(output_path), exist_ok=True)
-    fig.savefig(output_path, dpi=150, bbox_inches="tight")
-    plt.close(fig)
-    logger.info("Saved %s", output_path)
-
-
 def run_comparison(
     results_dir,
     output_dir,
     tech_colors,
-    scenario_filter=None,
-    country_shapes_path=None,
-    bus_regions_path=None,
+    scenario_filter,
+    label_map=None,
+    exclude_carriers=None,
 ):
-    networks = find_scenario_networks(results_dir, scenario_filter=scenario_filter)
+    networks = find_scenario_networks(results_dir, scenario_filter)
     if not networks:
         logger.warning("No .nc network files found under %s", results_dir)
         return
@@ -481,16 +334,34 @@ def run_comparison(
     logger.info("Found %d scenarios: %s", len(networks), list(networks.keys()))
     os.makedirs(output_dir, exist_ok=True)
 
-    capacity_df, generation_df, investment_df, co2_df, demand_s = build_comparison_dfs(
-        networks
+    capacity_df, generation_df, investment_df, co2_df, demand_s, display_colors = (
+        build_comparison_dfs(
+            networks,
+            tech_colors=tech_colors,
+            label_map=label_map,
+            exclude_carriers=exclude_carriers,
+        )
     )
+
+    if label_map:
+        # label_map insertion order defines the x-axis scenario order; define
+        # the mapping once and get ordering without a separate param.
+        preferred = list(label_map.values())
+        cols = [c for c in preferred if c in capacity_df.columns] + [
+            c for c in capacity_df.columns if c not in preferred
+        ]
+        capacity_df = capacity_df[cols]
+        generation_df = generation_df[cols]
+        investment_df = investment_df[cols]
+        co2_df = co2_df[cols]
+        demand_s = demand_s.reindex(cols)
 
     if not capacity_df.empty:
         plot_stacked_bar(
             capacity_df,
-            ylabel="Installed capacity [GW]",
+            ylabel="Installed capacity [GW / GWh]",
             title="Installed Capacity by Scenario",
-            tech_colors=tech_colors,
+            display_colors=display_colors,
             output_path=os.path.join(output_dir, "installed_capacity.png"),
         )
 
@@ -499,7 +370,7 @@ def run_comparison(
             generation_df,
             ylabel="Annual generation [TWh]",
             title="Generation Mix by Scenario",
-            tech_colors=tech_colors,
+            display_colors=display_colors,
             output_path=os.path.join(output_dir, "generation_mix.png"),
         )
 
@@ -508,7 +379,7 @@ def run_comparison(
             investment_df,
             ylabel="Annualised capital cost [EUR million/yr]",
             title="Investments by Scenario",
-            tech_colors=tech_colors,
+            display_colors=display_colors,
             output_path=os.path.join(output_dir, "investments.png"),
         )
 
@@ -517,31 +388,13 @@ def run_comparison(
             co2_df,
             ylabel="Annual CO₂ emissions [Mt CO₂/yr]",
             title="Carbon Emissions by Scenario",
-            tech_colors=tech_colors,
+            display_colors=display_colors,
             output_path=os.path.join(output_dir, "co2_emissions.png"),
             threshold=0.001,
         )
 
     if not demand_s.empty:
         plot_demand_bar(demand_s, os.path.join(output_dir, "demand.png"))
-
-    spatial_dir = os.path.join(output_dir, "spatial")
-    for label, path in networks.items():
-        try:
-            n = pypsa.Network(path)
-        except Exception as e:
-            logger.warning("Skipping spatial map for %s: %s", label, e)
-            continue
-        short = clean_scenario_label(label)
-        safe = short.replace(" ", "_").replace("/", "_")
-        plot_spatial_map(
-            n,
-            label=short,
-            tech_colors=tech_colors,
-            output_path=os.path.join(spatial_dir, "{}_spatial.png".format(safe)),
-            country_shapes_path=country_shapes_path,
-            bus_regions_path=bus_regions_path,
-        )
 
     logger.info("All comparison plots saved to %s", output_dir)
 
@@ -550,24 +403,25 @@ if __name__ == "__main__":
     if "snakemake" not in globals():
         from _helpers import mock_snakemake
 
-        snakemake = mock_snakemake("compare_scenarios", scenario_group="cap_exp_zambia")
+        snakemake = mock_snakemake(
+            "_compare_scenarios_group", scenario_group="cap_exp_zambia"
+        )
 
     configure_logging(snakemake)
 
     tech_colors = snakemake.config["plotting"]["tech_colors"]
     results_dir = snakemake.params.results_dir
-    scenario_filter = snakemake.params.get("scenario_filter", None)
-
-    country_shapes = os.path.join("resources", "shapes", "country_shapes.geojson")
-    bus_regions = os.path.join(
-        "resources", "bus_regions", "regions_onshore_elec_s_10.geojson"
-    )
+    sc_cfg = snakemake.config.get("plotting", {}).get("scenario_comparison", {})
+    # Exact run.name values to compare; defined in plotting.scenario_comparison.scenario_filter.
+    scenario_filter = sc_cfg.get("scenario_filter", [])
+    label_map = sc_cfg.get("label_map", None)
+    exclude_carriers = sc_cfg.get("exclude_carriers", [])
 
     run_comparison(
         results_dir=results_dir,
         output_dir=snakemake.output[0],
         tech_colors=tech_colors,
         scenario_filter=scenario_filter,
-        country_shapes_path=country_shapes,
-        bus_regions_path=bus_regions,
+        label_map=label_map,
+        exclude_carriers=exclude_carriers,
     )


### PR DESCRIPTION
## Closes #263 

## Changes proposed in this Pull Request

### Add cross-scenario comparison plots (`compare_scenarios`)

Adds `scripts/plot_scenario_comparison.py` and a `compare_scenarios` Snakemake rule that auto-discovers all solved networks under `results/` and produces comparison plots across scenarios.

### Outputs (`results/comparison_plots/`)

| Plot | Description |
|---|---|
| `installed_capacity.png` | Stacked bar chart of optimised capacity [GW] by technology |
| `generation_mix.png` | Stacked bar chart of annual generation [TWh] by technology |
| `demand.png` | Total annual electricity demand [TWh] per scenario |
| `investments.png` | Annualised capital cost [EUR million/yr] by technology |
| `co2_emissions.png` | Annual CO₂ emissions [Mt CO₂/yr] by emitting carrier |
| `spatial/<scenario>_spatial.png` | Geographic pie-chart map of generation mix at each bus |

Notes
- Networks are auto-discovered via `os.walk` on `results/`; root-level networks are skipped
- Carrier names and colours align with `config.plotting.tech_colors` keys
- Emissions derived from `n.carriers.co2_emissions` [tCO₂/MWh_el] populated at solve time
- Investments computed as `p_nom_opt × capital_cost` (annualised) from generators and storage units


## Checklist

<--This checklist must be filled in. If the item is not applicable, tick anyway.-->

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented, including updates to docstrings for meaningful functions.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/user-guide/configuration.md` and `doc/tutorials/electricity-model.md`.
- [ ] If config sections were added, renamed, or removed, update `doc/assets/scripts/extract_config_snippets.py` accordingly.
- [ ] Archives of the uploaded data do not have an enclosing folder and archive names correspond to the conventions of `configs/bundle_config.yaml`.
- [ ] A note for the release notes `doc/release-notes.md` is amended in the format of previous release notes, including reference to the requested PR.
