### PR TITLE
Priority dispatch for existing thermal plants                                                            

### DIFF
--- a/config.default.yaml
+++ b/config.default.yaml
@@ -223,6 +223,11 @@ electricity:
   powerplants_filter: (DateOut >= 2022 or DateOut != DateOut) and (DateIn <= 2023 or DateIn != DateIn)
   custom_powerplants: false #  "false" use only powerplantmatching (ppm) data, "merge" combines ppm and custom powerplants, "replace" use only custom powerplants
 
+  existing_thermal_dispatch:
+    enable: false
+    base_year: 2025
+    carriers: [coal, oil]
+
   conventional_carriers: [nuclear, oil, OCGT, CCGT, coal, lignite, geothermal, biomass]
   renewable_carriers: [solar, onwind, offwind-ac, offwind-dc, hydro]
 

--- a/configs/cap_exp_zambia.yaml
+++ b/configs/cap_exp_zambia.yaml
@@ -21,13 +21,18 @@ electricity:
   extendable_carriers:
     # TODO Biomass potential can have strong impact and must be adjusted
     # according to the conditions it aims to represent
-    Generator: ["solar", "biomass", "hydro", "ror", "oil", "onwind"]
+    Generator: ["solar", "onwind"]
     StorageUnit: []
     Store: []
     Link: []
 
   automatic_emission: false
   automatic_emission_base_year: 1990
+
+  existing_thermal_dispatch:
+    enable: true
+    base_year: 2025
+    carriers: [coal, oil]
 
   powerplants_filter: (DateOut >= 2025 or DateOut != DateOut) and (DateIn <= 2025 or DateIn != DateIn)
   custom_powerplants: replace
@@ -47,7 +52,7 @@ load_options:
   zambia_demand_distribution: true
 costs:
   marginal_cost:
-    coal: 0.0
+    coal: 72.92
     oil: 4.23
   co2_emissions: # tCO2/MWh — IRP Table 5 (Zambia 2023)
     hydro: 0.025

--- a/doc/configtables/snippets/electricity.yaml
+++ b/doc/configtables/snippets/electricity.yaml
@@ -31,6 +31,11 @@ electricity:
   powerplants_filter: (DateOut >= 2022 or DateOut != DateOut) and (DateIn <= 2023 or DateIn != DateIn)
   custom_powerplants: false #  "false" use only powerplantmatching (ppm) data, "merge" combines ppm and custom powerplants, "replace" use only custom powerplants
 
+  existing_thermal_dispatch:
+    enable: false
+    base_year: 2025
+    carriers: [coal, oil]
+
   conventional_carriers: [nuclear, oil, OCGT, CCGT, coal, lignite, geothermal, biomass]
   renewable_carriers: [solar, onwind, offwind-ac, offwind-dc, hydro]
 

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -97,6 +97,7 @@ from powerplantmatching.export import map_country_bus
 from utility_custom_features import (
     add_biomass_potential,
     disaggregate_plants,
+    set_existing_thermal_zero_mc,
 )
 
 idx = pd.IndexSlice
@@ -773,6 +774,16 @@ def attach_conventional_generators(
         build_year=ppl_grouped["build_year"],
         lifetime=ppl_grouped["lifetime"],
     )
+
+    thermal_config = snakemake.config["electricity"].get(
+        "existing_thermal_dispatch", {}
+    )
+    if thermal_config.get("enable", False):
+        set_existing_thermal_zero_mc(
+            n,
+            base_year=thermal_config["base_year"],
+            carriers=thermal_config["carriers"],
+        )
 
     # Add extendable conventional generators
     extendable_conventional = set(extendable_carriers["Generator"]) - set(

--- a/scripts/utility_custom_features.py
+++ b/scripts/utility_custom_features.py
@@ -482,3 +482,13 @@ def build_mining_raster(
         dst.write(raster, 1)
 
     return output_path
+
+
+def set_existing_thermal_zero_mc(n, base_year, carriers):
+    mask = (
+        n.generators.carrier.isin(carriers)
+        & ~n.generators.p_nom_extendable
+        & (n.generators.build_year <= base_year)
+    )
+    n.generators.loc[mask, "marginal_cost"] = 0.0
+    logger.info(f"Zero marginal cost applied to: {n.generators.index[mask].tolist()}")


### PR DESCRIPTION
->

## Changes proposed in this Pull Request
  Sets marginal cost to zero for existing coal and fuel oil plants (built ≤ 2025) so they always     
  dispatch ahead of new investments, consistent with the IRP assumption. Proposed plants (Maamba     
  Phase 2+) keep the IRP fuel cost and compete on merit order. Controlled by an                      
  existing_thermal_dispatch flag in the config, off by default. 
<--Add a summary of what the contribution contains -->

## Checklist

<--This checklist must be filled in. If the item is not applicable, tick anyway.-->

- [ ] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented, including updates to docstrings for meaningful functions.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/user-guide/configuration.md` and `doc/tutorials/electricity-model.md`.
- [ ] If config sections were added, renamed, or removed, update `doc/assets/scripts/extract_config_snippets.py` accordingly.
- [ ] Archives of the uploaded data do not have an enclosing folder and archive names correspond to the conventions of `configs/bundle_config.yaml`.
- [ ] A note for the release notes `doc/release-notes.md` is amended in the format of previous release notes, including reference to the requested PR.
